### PR TITLE
Fixed with pathlib had extra brackets, this should be os independent

### DIFF
--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -25,5 +25,5 @@ def test_log_output_in_pqr_location(capture, input_file, output_file, tmp_path):
     # This match tests that the log file is output to the same location
     # as the output pqr
     capture.check_present(
-        ('pdb2pqr.input_output', 'INFO', f'Logs stored: {tmp_path}/{output_file.split(".")[0]}.log')
+        ('pdb2pqr.input_output', 'INFO', f'Logs stored: {tmp_path / output_file.split(".")[0]}.log')
     )


### PR DESCRIPTION
Sorry about that, I forgot to delete a couple curly brackets so it wasn't using pathlib (OS independence) and was instead hard coded path char.  I tested on a windows VM and passed.