### PR TITLE
Fix elements of created atoms

### DIFF
--- a/pdb2pqr/aa.py
+++ b/pdb2pqr/aa.py
@@ -945,6 +945,7 @@ class WAT(residue.Residue):
         newatom.y = newcoords[1]
         newatom.z = newcoords[2]
         newatom.name = atomname
+        newatom.element = atomname[0]
         newatom.occupancy = 1.00
         newatom.temp_factor = 0.00
         newatom.added = 1
@@ -1030,6 +1031,7 @@ class LIG(residue.Residue):
         newatom.y = newcoords[1]
         newatom.z = newcoords[2]
         newatom.name = atomname
+        newatom.element = atomname[0]
         newatom.occupancy = 1.00
         newatom.temp_factor = 0.00
         newatom.added = 1


### PR DESCRIPTION
I don't like much this approach since there can exist atoms in some FFs which don't have the element as the first letter. But the real fix would require storing the elements in the FF files and would require more refactoring. In any case this fixes issue 
https://github.com/Electrostatics/pdb2pqr/issues/193 