### PR TITLE
Fixed long lines and typo in logging

### DIFF
--- a/pdb2pqr/biomolecule.py
+++ b/pdb2pqr/biomolecule.py
@@ -70,7 +70,8 @@ class Biomolecule(object):
                             )[count]
                         except IndexError:
                             raise Exception(
-                                "Too many chains exist in biomolecule. Consider preparing subsets."
+                                "Too many chains exist in biomolecule. "
+                                "Consider preparing subsets."
                             )
 
                 chain_id = record.chain_id

--- a/pdb2pqr/io.py
+++ b/pdb2pqr/io.py
@@ -506,13 +506,14 @@ def setup_logger(output_pqr, level="DEBUG"):
     # Get the output logging location
     output_pth = Path(output_pqr)
     log_file = Path(output_pth.parent, output_pth.stem + ".log")
+    log_format = (
+        "%(asctime)s %(levelname)s:%(filename)s:"
+        "%(lineno)d:%(funcName)s:%(message)s"
+    )
     _LOGGER.info(f"Logs stored: {log_file}")
     logging.basicConfig(
         filename=log_file,
-        format=(
-            "%(asctime)s %(levelname)s:%(filename)s:",
-            "%(lineno)d:%(funcName)s:%(message)s",
-        ),
+        format=log_format,
         level=getattr(logging, level),
     )
     console = logging.StreamHandler()

--- a/pdb2pqr/psize.py
+++ b/pdb2pqr/psize.py
@@ -24,7 +24,7 @@ FADD = 20.0
 CFAC = 1.7
 #: Desired fine grid spacing (in Angstroms)
 SPACE = 0.50
-#: Approximate memory usage (in bytes) can be estimated by multiplying the 
+#: Approximate memory usage (in bytes) can be estimated by multiplying the
 #: number of grid points by this constant
 GMEMFAC = 200
 #: Maxmimum memory (in MB) to be used for a calculation

--- a/pdb2pqr/structures.py
+++ b/pdb2pqr/structures.py
@@ -328,7 +328,8 @@ class Atom:
         :rtype:  str
         """
         outstr = self.get_common_string_rep(chainflag=True)
-        outstr += f"{self.occupancy:>6.2f}{self.temp_factor:>6.2f}      {self.seg_id:4.4s}{self.element:>2.2s}{self.charge:2.2s}"
+        outstr += f"{self.occupancy:>6.2f}{self.temp_factor:>6.2f}      "
+        outstr += f"{self.seg_id:4.4s}{self.element:>2.2s}{self.charge:2.2s}"
         return outstr
 
     @property


### PR DESCRIPTION
I made a typo in the logging format.
I fixed a few other "line too long" warnings from flake.
Pylint has WAY too many warnings to try and fix in this request. I will write another issue.