### PR TITLE
Check and return exit code if CRITICAL error

### DIFF
--- a/pdb2pqr/__init__.py
+++ b/pdb2pqr/__init__.py
@@ -7,7 +7,7 @@ For more information, see http://www.poissonboltzmann.org/
 """
 import logging
 from sys import version_info
-from .main import main_driver, build_main_parser
+from .main import main
 from ._version import __version__  # noqa: F401
 
 
@@ -19,6 +19,4 @@ logging.captureWarnings(True)
 
 
 if __name__ == "__main__":
-    PARSER = build_main_parser()
-    ARGS = PARSER.parse_args()
-    _ = main_driver(ARGS)
+    main()

--- a/pdb2pqr/__main__.py
+++ b/pdb2pqr/__main__.py
@@ -7,7 +7,7 @@ For more information, see http://www.poissonboltzmann.org/
 """
 import logging
 from sys import version_info
-from pdb2pqr.main import main_driver, build_main_parser
+from pdb2pqr.main import main
 
 assert version_info >= (3, 5)
 
@@ -17,6 +17,4 @@ logging.captureWarnings(True)
 
 
 if __name__ == "__main__":
-    PARSER = build_main_parser()
-    ARGS = PARSER.parse_args()
-    _ = main_driver(ARGS)
+    main()

--- a/pdb2pqr/main.py
+++ b/pdb2pqr/main.py
@@ -8,6 +8,7 @@ It was created to avoid cluttering the __init__.py file.
 """
 import logging
 import argparse
+import sys
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 from pathlib import Path
@@ -781,7 +782,7 @@ def main_driver(args):
         except ValueError as err:
             _LOGGER.critical(err)
             _LOGGER.critical("Giving up.")
-            return
+            return 1
     print_pqr(
         args=args,
         pqr_lines=results["lines"],
@@ -809,6 +810,8 @@ def main():
     parser = build_main_parser()
     args = parser.parse_args()
     _ = main_driver(args)
+    if _ == 1:
+        sys.exit(_)
 
 
 def dx_to_cube():

--- a/pdb2pqr/main.py
+++ b/pdb2pqr/main.py
@@ -809,9 +809,8 @@ def main():
     """Hook for command-line usage."""
     parser = build_main_parser()
     args = parser.parse_args()
-    _ = main_driver(args)
-    if _ == 1:
-        sys.exit(_)
+    if main_driver(args) == 1:
+        sys.exit(1)
 
 
 def dx_to_cube():


### PR DESCRIPTION
Fixes #223 

### Other changes:
* Simplified parsing by calling `main()` from `__init__.py` and `__main__.py`