### PR TITLE
Override `--version` argument set by PROPKA

### DIFF
--- a/pdb2pqr/main.py
+++ b/pdb2pqr/main.py
@@ -48,6 +48,7 @@ def build_main_parser():
     """
     desc = TITLE_STR
     pars = argparse.ArgumentParser(
+        prog="pdb2pqr",
         description=desc,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         conflict_handler="resolve",

--- a/pdb2pqr/main.py
+++ b/pdb2pqr/main.py
@@ -50,6 +50,7 @@ def build_main_parser():
     pars = argparse.ArgumentParser(
         description=desc,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        conflict_handler="resolve",
     )
     pars.add_argument(
         "input_path",
@@ -222,6 +223,12 @@ def build_main_parser():
         ),
     )
     pars = propka.lib.build_parser(pars)
+
+    # Override version flag set by PROPKA
+    pars.add_argument(
+        "--version", action="version", version=f"%(prog)s {VERSION}"
+    )
+
     return pars
 
 


### PR DESCRIPTION
Fixes #217 

Because PROPKA set the `--version` flag alongside the fact that we import it's argparse group to our parser, I set the [conflict_handler parameter](https://docs.python.org/3/library/argparse.html#conflict-handler) to `'resolve'`.  This can carry the side effect of unintended overrides should we add additional arguments in the future.

### Before (assuming PDB2PQR v3.2.2)
```bash
$ pdb2pqr30 --version
pdb2pqr30 3.4.0

$ python -m pdb2pqr --version
__main__.py 3.4.0
```
Version number displayed above was inherited from the PROPKA parser

### After
```bash
$ pdb2pqr30 --version
pdb2pqr 3.2.2

$ python -m pdb2pqr --version
pdb2pqr 3.2.2
```