### PR TITLE
Allow users to disable protonation on specific residues

### DIFF
--- a/pdb2pqr/biomolecule.py
+++ b/pdb2pqr/biomolecule.py
@@ -348,8 +348,9 @@ class Biomolecule(object):
         for residue in self.residues:
             if not isinstance(residue, (aa.Amino, na.Nucleic)):
                 continue
+
             reskey = (residue.res_seq, residue.chain_id, residue.ins_code)
-            if reskey in hlist:
+            if hlist is not None and reskey in hlist:
                 continue
 
             for atomname in residue.reference.map:


### PR DESCRIPTION
Hi, I sometimes don't want to protonate the whole protein. For example some protein residues are covalently bonded to ligands and should not be protonated by pdb2pqr as if they were free.
What do you think about adding the option? 