### PR TITLE
Fix issue with wrong pkas assigned to terminal residues

### DIFF
--- a/pdb2pqr/main.py
+++ b/pdb2pqr/main.py
@@ -637,7 +637,7 @@ def non_trivial(args, biomolecule, ligand, definition, is_cif):
             biomolecule.apply_pka_values(
                 forcefield_.name,
                 args.ph,
-                {f"{row['res_name']} {row['res_num']} {row['chain_id']}": row["pKa"] for row in pka_df},
+                {f"{row['res_name']} {row['res_num']} {row['chain_id']}": row["pKa"] for row in pka_df if row["res_name"] == row["group_type"]},
             )
 
         _LOGGER.info("Adding hydrogens to biomolecule.")

--- a/pdb2pqr/main.py
+++ b/pdb2pqr/main.py
@@ -637,7 +637,7 @@ def non_trivial(args, biomolecule, ligand, definition, is_cif):
             biomolecule.apply_pka_values(
                 forcefield_.name,
                 args.ph,
-                {f"{row['res_name']} {row['res_num']} {row['chain_id']}": row["pKa"] for row in pka_df if row["res_name"] == row["group_type"]},
+                {f"{row['res_name']} {row['res_num']} {row['chain_id']}": row["pKa"] for row in pka_df if row["group_label"].startswith(row["res_name"])},
             )
 
         _LOGGER.info("Adding hydrogens to biomolecule.")


### PR DESCRIPTION
Solves https://github.com/Electrostatics/pdb2pqr/issues/245

I'm not 1000% sure this is the best way to solve it but I checked a few PDBs and it seems like the group_type matches the res_name when you want to get the pKa of the sidechain.