### PR TITLE
Fix bug and add support for integer resnames which exist in PDB

### DIFF
--- a/pdb2pqr/definitions.py
+++ b/pdb2pqr/definitions.py
@@ -101,11 +101,14 @@ class DefinitionHandler(sax.ContentHandler):
         if text.isspace():
             return
         _LOGGER.debug(f"Got text for <{self.curelement}>: {text}")
-        # If this is a float, make it so
-        try:
-            value = float(str(text))
-        except ValueError:
-            value = str(text)
+
+        # If this is a float, make it so. Except for residue names which should stay string
+        value = str(text)
+        if self.curelement != "name":
+            try:
+                value = float(value)
+            except ValueError:
+                pass
 
         # Special cases - lists and dictionaries
         if self.curelement == "bond":


### PR DESCRIPTION
Currently if you add a residue with an integer name to the XML definitions it will crash because it will convert the resname to a float number which will not match any class definitions.

https://www.rcsb.org/structure/5VBL
Here for example you have residue 200 (4-CHLORO-L-PHENYLALANINE)
https://www.rcsb.org/ligand/200

This PR fixes that issue by insisting on string type for residue names even if they can be converted to float.

