### PR TITLE
Missing heavy atoms error erroring

### DIFF
--- a/pdb2pqr/main.py
+++ b/pdb2pqr/main.py
@@ -461,7 +461,7 @@ def is_repairable(biomolecule, has_ligand):
     miss_frac = float(num_missing) / float(num_heavy)
     if miss_frac > REPAIR_LIMIT:
         error = f"This PDB file is missing too many ({num_missing} out of "
-        error += f"{num_heavy:i}, {miss_frac:g}) "
+        error += f"{num_heavy:d}, {miss_frac:g}) "
         error += "heavy atoms to accurately repair the file."
         error += f"The current repair limit is set at {REPAIR_LIMIT:g}. "
         error += "You may also see this message if PDB2PQR does not have "


### PR DESCRIPTION
Fixes this error when not enough heavy atoms exist

```py
File ~/miniconda3/envs/htmd3.9/lib/python3.9/site-packages/pdb2pqr/main.py:465, in is_repairable(biomolecule, has_ligand)
    463 if miss_frac > REPAIR_LIMIT:
    464     error = f"This PDB file is missing too many ({num_missing} out of "
--> 465     error += f"{num_heavy:i}, {miss_frac:g}) "
    466     error += "heavy atoms to accurately repair the file."
    467     error += f"The current repair limit is set at {REPAIR_LIMIT:g}. "

ValueError: Unknown format code 'i' for object of type 'int'
```