### PR TITLE
Fix `io.test_for_file` failing for editable installs

### DIFF
--- a/pdb2pqr/io.py
+++ b/pdb2pqr/io.py
@@ -359,19 +359,20 @@ def test_for_file(name, type_):
         return ""
     test_names = [name, name.upper(), name.lower()]
     test_suffixes = ["", f".{type_.upper()}", f".{type_.lower()}"]
-    test_dirs = [
-        Path(p).joinpath("pdb2pqr", "dat") for p in sys_path + [Path.cwd()]
-    ]
+
+    module_path = Path(__file__)
+    dirpath_dat = module_path.parent / 'dat'
+
+    assert dirpath_dat.is_dir()
+
     if name.lower() in FORCE_FIELDS:
         name = name.upper()
-    for test_dir in test_dirs:
-        test_dir = Path(test_dir)
-        for test_name in test_names:
-            for test_suffix in test_suffixes:
-                test_path = test_dir / (test_name + test_suffix)
-                if test_path.is_file():
-                    _LOGGER.debug(f"Found {type_} file {test_path}")
-                    return test_path
+    for test_name in test_names:
+        for test_suffix in test_suffixes:
+            test_path = dirpath_dat / (test_name + test_suffix)
+            if test_path.is_file():
+                _LOGGER.debug(f"Found {type_} file {test_path}")
+                return test_path
     err = f"Unable to find {type_} file for {name}"
     raise FileNotFoundError(err)
 


### PR DESCRIPTION
Fixes #6 

The `io.test_for_file` function would fail to find files that are actually present in the `pdb2pqr/dat` folder if the package was installed in editable mode. The reason is that in editable mode the files are not actually copied to a path that is in the `PYTHONPATH` but the source tree is simply symlinked. Since the code was only checking base directories that are the current working directory or part of `sys.path`, files were never found.

There the absolute path of `pdb2pqr/dat` is determined by simply getting the filepath of the `pdb2pqr.io` module and then getting the `dat` folder through relative path operations. This should work for all manner of installing.