### PR TITLE
fix: shadowed module recovered `pdb2pqr.main`

### DIFF
--- a/pdb2pqr/__init__.py
+++ b/pdb2pqr/__init__.py
@@ -7,7 +7,7 @@ For more information, see http://www.poissonboltzmann.org/
 """
 import logging
 from sys import version_info
-from .main import main
+from .main import main as pdb2pqr_main
 from ._version import __version__  # noqa: F401
 
 
@@ -19,4 +19,4 @@ logging.captureWarnings(True)
 
 
 if __name__ == "__main__":
-    main()
+    pdb2pqr_main()


### PR DESCRIPTION
It was impossible to import `import pdb2pqr.main` or use any of the functions in the module because it was shadowed by the name in `pdb2pqr.__init__.py`'s `main()` function. Importing that module will just import the function and the others weren't available.

This allows users to use pdb2pqr as a module, not necessarily as a CLI. Here's an example:

```python
from pdb2pqr.main import build_main_parser, main_driver

parser = build_main_parser()
args = parser.parse_args(["-h"])  # just like `pdb2pqr -h`
main_driver(args)
```

This is a much cleaner way to integrate pdb2pqr in a python project, rather than having to make a subprocess running.  
The reason is that this allows users to adapt debuggers or see the full traceback of PDB2PQR!

In addition, I'm willing to make a simple wrapper of a PDB2PQR like `from pdb2pqr import run_pdb2pqr`, but I think this can be the next PR separate from this.