### PR TITLE
feat: run pdb2pqr in python (no CLI)

### DIFF
--- a/pdb2pqr/__init__.py
+++ b/pdb2pqr/__init__.py
@@ -10,6 +10,7 @@ import logging
 
 from ._version import __version__
 from .main import main as pdb2pqr_main
+from .main import run_pdb2pqr
 
 _LOGGER = logging.getLogger(__name__)
 logging.captureWarnings(capture=True)

--- a/ruff_essential.toml
+++ b/ruff_essential.toml
@@ -7,4 +7,5 @@ select = [
   "F63",
   "F7",
   "F82",
+  "FA102",  # Python 3.10-style union typing is used so we need to import `from __future__ import annotations`
 ]

--- a/tests/common.py
+++ b/tests/common.py
@@ -203,7 +203,7 @@ def compare_pqr(pqr1_path, pqr2_path, compare_resnames=False):
                 _LOGGER.info(result)
 
 
-def run_pdb2pqr(
+def run_pdb2pqr_for_tests(
     args,
     input_pdb,
     tmp_path,

--- a/tests/common.py
+++ b/tests/common.py
@@ -212,6 +212,8 @@ def run_pdb2pqr_for_tests(
     compare_resnames=False,
 ):
     """Basic code for invoking PDB2PQR."""
+    from pdb2pqr import io
+
     if output_pqr is None:
         hash_str = f"{args}{input_pdb}"
         hash_ = hashlib.sha1(hash_str.encode("UTF-8")).hexdigest()
@@ -220,6 +222,7 @@ def run_pdb2pqr_for_tests(
     _LOGGER.debug(f"Writing output to {output_pqr}")
     arg_str = f"{args} {input_pdb} {output_pqr}"
     args = PARSER.parse_args(arg_str.split())
+    io.setup_logger(args.output_pqr, args.log_level)
     _ = main_driver(args)
     if expected_pqr is not None:
         compare_pqr(

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -65,7 +65,7 @@ def test_short_pdb(input_pdb, tmp_path):
     """Non-regression tests on short list of PDB-format biomolecules."""
     args = "--log-level=INFO --ff=AMBER --drop-water --apbs-input=apbs.in"
     output_pqr = Path(input_pdb).stem + ".pqr"
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_pdb,
         output_pqr=output_pqr,
@@ -78,7 +78,7 @@ def test_basic_cif(input_pdb, tmp_path):
     """Non-regression tests on short list of CIF-format biomolecules."""
     args = "--log-level=INFO --ff=AMBER --drop-water --apbs-input=apbs.in"
     output_pqr = Path(input_pdb).stem + ".cif"
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_pdb,
         output_pqr=output_pqr,
@@ -92,7 +92,7 @@ def test_long_pdb(input_pdb, tmp_path):
     """Non-regression tests on short list of PDB-format biomolecules."""
     args = "--log-level=INFO --ff=AMBER --drop-water --apbs-input=apbs.in"
     output_pqr = Path(input_pdb).stem + ".pqr"
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_pdb,
         output_pqr=output_pqr,
@@ -106,7 +106,7 @@ def test_broken_backbone(input_pdb, tmp_path):
     """Test graceful failure of optimization with missing backbone atoms."""
     args = "--log-level=INFO --ff=AMBER --drop-water"
     output_pqr = Path(input_pdb).stem + ".pqr"
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_pdb,
         output_pqr=output_pqr,
@@ -122,7 +122,7 @@ def test_protonated_terminals(input_pdb, expected_pqr, tmp_path):
     """Tests for terminal residue protonation."""
     args = "--log-level=INFO --ff=AMBER --ffout AMBER"
     output_pqr = Path(input_pdb).stem + ".pqr"
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=common.DATA_DIR / input_pdb,
         output_pqr=output_pqr,
@@ -146,7 +146,7 @@ def test_cyclic_peptide(input_pdb, expected_pqr, tmp_path):
     """Tests for cyclic peptide protonation."""
     args = "--log-level=INFO --ff=AMBER --ffout AMBER"
     output_pqr = Path(input_pdb).stem + ".pqr"
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=common.DATA_DIR / input_pdb,
         output_pqr=output_pqr,
@@ -170,7 +170,7 @@ def test_ph_naming(naming_test, tmp_path):
         f"--drop-water --whitespace --with-ph={naming_test['pH']} "
         f"--titration-state-method=propka"
     )
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=common.DATA_DIR / input_pdb,
         output_pqr=output_pqr,

--- a/tests/ligand_test.py
+++ b/tests/ligand_test.py
@@ -188,7 +188,7 @@ def test_ligand_biomolecule(input_pdb, tmp_path):
     args = f"--log-level=INFO --ff=AMBER --drop-water --ligand={ligand}"
     output_pqr = Path(input_pdb).stem + ".pqr"
     _LOGGER.debug(f"Running test in {tmp_path}")
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_pdb,
         output_pqr=output_pqr,

--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -21,7 +21,7 @@ def test_log_output_in_pqr_location(
     args = "--log-level=INFO --ff=AMBER"
     input_path = common.DATA_DIR / input_file
     output_pqr = output_file
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_path,
         output_pqr=output_pqr,

--- a/tests/propka_test.py
+++ b/tests/propka_test.py
@@ -16,7 +16,7 @@ def test_propka_apo(input_pdb, tmp_path):
         "--titration-state-method=propka"
     )
     output_pqr = Path(input_pdb).stem + ".pqr"
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_pdb,
         output_pqr=output_pqr,

--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -29,7 +29,7 @@ _LOGGER = logging.getLogger(__name__)
 )
 def test_basic(args, input_pdb, output_pqr, expected_pqr, tmp_path):
     """Basic code to run 1AFS."""
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_pdb,
         output_pqr=output_pqr,
@@ -87,7 +87,7 @@ def test_basic(args, input_pdb, output_pqr, expected_pqr, tmp_path):
 )
 def test_forcefields(args, input_pdb, output_pqr, expected_pqr, tmp_path):
     """Basic code to run 1AFS with --whitespace for different forcefields."""
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_pdb,
         output_pqr=output_pqr,
@@ -153,7 +153,7 @@ def test_forcefields(args, input_pdb, output_pqr, expected_pqr, tmp_path):
 )
 def test_other_options(args, input_pdb, output_pqr, expected_pqr, tmp_path):
     """Basic code to run 1AFS with --whitespace."""
-    common.run_pdb2pqr(
+    common.run_pdb2pqr_for_tests(
         args=args,
         input_pdb=input_pdb,
         output_pqr=output_pqr,


### PR DESCRIPTION
Closes #405 

Usage:

```python
from pdb2pqr import run_pdb2pqr

run_pdb2pqr(["-h"])
```

Changes:

- There already is `run_pdb2pqr` in `tests/common.py` function for tests. To make the naming consistent and not confusing, I changed it to `run_pdb2pqr_for_tests` just like another function in the module called `run_propka_for_tests`.
- `main_driver()` doesn't include `io.setup_logger()` call anymore. It's moved to `main()` instead for maximum flexibility.