### PR TITLE
Bamattsson/fix build failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,11 +74,11 @@ test = [
   "sphinx-rtd-theme",
 ]
 pkaani = [
-  "setuptools<=81",
   "ase",
   "joblib",
   "scipy",
   "scikit-learn>=1.6.1",
+  "setuptools<=81",
   "torch",
   "torchani<=2.2.4",
   "pkaani",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,13 @@ test = [
   "sphinx-rtd-theme",
 ]
 pkaani = [
+  "setuptools<=81",
   "ase",
   "joblib",
   "scipy",
   "scikit-learn>=1.6.1",
   "torch",
-  "torchani",
+  "torchani<=2.2.4",
   "pkaani",
   "tabulate"
 ]


### PR DESCRIPTION
Hi @sobolevnrm @sastrys1!

I was waiting for a run to finish this morning so decide to see if I could figure this out. I think I found the root cause and resolved it.

In terms of why this build is all of a sudden failing I found a double-whammy of two problems:
- A. the pdb2pqr.pkaani module doesn't support torchani versions newer than 2.2.4. The next pypi published version (2.7.1) which was released on 11 Nov 2025 makes 3.10 fail ([link](https://github.com/aiqm/torchani/releases))
- B. However, torchani<=2.2.4 requires the package `pkg_resources`. `pkg_resources` used to be released with setuptools, hence `torchani` never specified this as an explicit requirement, so we need to do that now, otherwise torchani fails due to this. If that wasn't enough, in the latests setuptools version 82.0 (released 8th of Feb this year) setuptools have dropped pkg_resources entirely, hence we need to pin the setuptools version to <=81.0 ([link](https://setuptools.pypa.io/en/stable/history.html)). 

I first replicated the errors from GH actions locally, added these changes and then tested this locally on 3.10 and 3.13 and it works. So I think it's worth triggering a build to see if this works in the GH actions setup.