### PR TITLE
build: remove unused docutils dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
   "numpy",
   "propka >= 3.5",
   "requests",
-  "docutils",
   "typing-extensions",
 ]
 


### PR DESCRIPTION
Fixes #432

Removes `docutils` from the runtime dependency list in `pyproject.toml`. I checked the repository and it is not imported from package or test code, so keeping it as an install requirement appears unnecessary.

Validation:
- built sdist and wheel with `python -m build`
- installed the package into a fresh virtualenv with `python -m pip install .`
- verified installed metadata no longer lists `docutils` as a requirement
- verified `import pdb2pqr` succeeds after install